### PR TITLE
Fix babel preset options caching

### DIFF
--- a/lib/webpack/loaders/ream-babel-loader.js
+++ b/lib/webpack/loaders/ream-babel-loader.js
@@ -3,7 +3,6 @@ const logger = require('../../logger')
 
 module.exports = babelLoader.custom(babel => {
   const configs = new Set()
-  let reamPresetItem
 
   return {
     customOptions(opts) {
@@ -24,14 +23,12 @@ module.exports = babelLoader.custom(babel => {
         }
       }
 
-      reamPresetItem =
-        reamPresetItem ||
-        babel.createConfigItem(
-          [require.resolve('../../babel/preset'), customOptions],
-          {
-            type: 'preset'
-          }
-        )
+      const reamPresetItem = babel.createConfigItem(
+        [require.resolve('../../babel/preset'), customOptions],
+        {
+          type: 'preset'
+        }
+      )
 
       // Add our default preset
       options.presets = [reamPresetItem, ...options.presets]


### PR DESCRIPTION
Babel preset options were cached mistakenly between server and client
compiles.

Fixes https://github.com/ream/ream/issues/140